### PR TITLE
Add format check workflow for C++ and Python (#10)

### DIFF
--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -1,0 +1,44 @@
+# Check C++ (clang-format) and Python (ruff) formatting on pull requests.
+name: Format check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install ruff only (no project build)
+        run: |
+          uv venv
+          uv pip install --python .venv/bin/python ruff
+
+      - name: Install clang-format
+        run: sudo apt-get update && sudo apt-get install -y clang-format
+
+      - name: Check C++ formatting (clang-format)
+        run: |
+          FILES=$(find src bindings -type f \( -name '*.cpp' -o -name '*.h' \) 2>/dev/null || true)
+          if [ -n "$FILES" ]; then
+            echo "$FILES" | xargs clang-format --dry-run --Werror
+          else
+            echo "No C++ sources under src/ or bindings/."
+          fi
+
+      - name: Check Python formatting and lint (ruff)
+        run: |
+          .venv/bin/ruff format --check .
+          .venv/bin/ruff check .

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,11 +86,15 @@ C++ formatting is defined for files under `src/` and `bindings/`:
 .\scripts\format.ps1
 ```
 
-Python formatting and lint checks:
+Python formatting and lint:
+
+- To **check** only (same as CI): `uv run ruff format --check .` and `uv run ruff check .`
+- To **fix** formatting: `uv run ruff format .` then run `uv run ruff check .`
 
 ```bash
-uv run ruff format .
+uv run ruff format --check .
 uv run ruff check .
+# If format check fails: uv run ruff format . then re-run checks.
 ```
 
 ## Agent checklist after code changes
@@ -98,5 +102,5 @@ uv run ruff check .
 1. If you changed C++ in `src/` or `bindings/`, run the formatting script.
 2. Ensure the project builds (installable or standalone CMake path).
 3. Run relevant tests (at minimum `uv run pytest tests/ -v`; include `ctest` for C++ changes).
-4. Run Python formatting/lint checks (`uv run ruff format .` and `uv run ruff check .`).
+4. Run Python format/lint: `uv run ruff format --check .` and `uv run ruff check .`; if format check fails, run `uv run ruff format .` and re-check.
 5. Review diffs and confirm generated formatting changes are included in your commit.

--- a/README.md
+++ b/README.md
@@ -178,6 +178,17 @@ C++ under `src/` and `bindings/` is formatted with [clang-format](https://clang.
 
 Requires `clang-format` on your PATH.
 
+## Code formatting (Python)
+
+Python is formatted and linted with [ruff](https://docs.astral.sh/ruff/). From the repo root:
+
+```bash
+uv run ruff format --check .    # verify only (CI runs this)
+uv run ruff check .             # lint
+```
+
+To fix formatting: `uv run ruff format .` then re-run the checks.
+
 ## Python API
 
 ### Geometry primitives (`meshTools.geometry`)

--- a/python/meshTools/chull.py
+++ b/python/meshTools/chull.py
@@ -14,10 +14,12 @@ debug = False
 
 try:
     from . import _chull
+
     _CHull = _chull.Hull
 except ImportError:
     try:
         import _chull
+
         _CHull = _chull.Hull
     except ImportError:
         _CHull = None

--- a/python/meshTools/delaunay.py
+++ b/python/meshTools/delaunay.py
@@ -15,10 +15,12 @@ logger = logging.getLogger(__name__)
 
 try:
     from . import _delaunay
+
     _DelaunayCpp = _delaunay.Delaunay
 except ImportError:
     try:
         import _delaunay
+
         _DelaunayCpp = _delaunay.Delaunay
     except ImportError:
         _DelaunayCpp = None

--- a/python/meshTools/noise.py
+++ b/python/meshTools/noise.py
@@ -14,10 +14,12 @@ TABMASK = 0xFF
 
 try:
     from . import _noise
+
     _NoiseCpp = _noise.Noise
 except ImportError:
     try:
         import _noise
+
         _NoiseCpp = _noise.Noise
     except ImportError:
         _NoiseCpp = None
@@ -551,7 +553,9 @@ def _make_noise_class():
             if len(args) == 3:
                 return list(self._impl.vsnoise(args[0], args[1], args[2]))
             if len(args) == 4:
-                return list(self._impl.vsnoise(args[0], args[1], args[2], args[3]))
+                return list(
+                    self._impl.vsnoise(args[0], args[1], args[2], args[3])
+                )
             raise TypeError("vsnoise takes 1, 2, 3, or 4 arguments")
 
         def fBm(self, x, y, z, octaves, lacunarity, gain):
@@ -564,7 +568,9 @@ def _make_noise_class():
             return list(self._impl.vfBm(x, y, z, octaves, lacunarity, gain))
 
         def vturbulence(self, x, y, z, octaves, lacunarity, gain):
-            return list(self._impl.vturbulence(x, y, z, octaves, lacunarity, gain))
+            return list(
+                self._impl.vturbulence(x, y, z, octaves, lacunarity, gain)
+            )
 
     return Noise
 

--- a/src/bezier/curves.h
+++ b/src/bezier/curves.h
@@ -154,7 +154,7 @@ class Spline {
 class Spline1 {
   public:
     /** @brief Default constructor */
-    Spline1() {};
+    Spline1() {}
 
     /**
      * @brief Interpolate control points


### PR DESCRIPTION
- Introduced a GitHub Actions workflow to check code formatting for C++ (using clang-format) and Python (using ruff) on pull requests.
- The workflow includes steps for setting up the environment, installing necessary tools, and running formatting checks.
- Ensures consistent code style and adherence to formatting standards across the project.