### PR TITLE
Refactor module export functions and variable names for consistency

### DIFF
--- a/bindings/bezier/module_bezier.cpp
+++ b/bindings/bezier/module_bezier.cpp
@@ -8,7 +8,7 @@
 
 namespace nb = nanobind;
 
-void export_bezier_module(nb::module_ &m) {
+void exportBezierModule(nb::module_ &m) {
     nb::class_<curves::Bezier>(m, "Bezier")
         .def(nb::init<>())
         .def(nb::init<std::vector<float>>())
@@ -25,4 +25,4 @@ void export_bezier_module(nb::module_ &m) {
         .def("interpolate", &curves::Spline::interpolate);
 }
 
-NB_MODULE(_bezier, m) { export_bezier_module(m); }
+NB_MODULE(_bezier, m) { exportBezierModule(m); }

--- a/bindings/chull/module_chull.cpp
+++ b/bindings/chull/module_chull.cpp
@@ -9,7 +9,7 @@ using namespace nb::literals;
 namespace meshTools {
 namespace Chull {
 
-void export_chull_module(nb::module_ &m) {
+void exportChullModule(nb::module_ &m) {
     nb::class_<Hull>(m, "Hull",
                      "Convex hull of a 3D point set. Use exportHull() for "
                      "[faces, vertices].")
@@ -38,4 +38,4 @@ void export_chull_module(nb::module_ &m) {
 } // namespace Chull
 } // namespace meshTools
 
-NB_MODULE(_chull, m) { meshTools::Chull::export_chull_module(m); }
+NB_MODULE(_chull, m) { meshTools::Chull::exportChullModule(m); }

--- a/bindings/delaunay/module_delaunay.cpp
+++ b/bindings/delaunay/module_delaunay.cpp
@@ -9,7 +9,7 @@ using namespace nb::literals;
 namespace meshTools {
 namespace Delaunay {
 
-void export_delaunay_module(nb::module_ &m) {
+void exportDelaunayModule(nb::module_ &m) {
     nb::class_<Delaunay>(m, "Delaunay",
                          "3D Delaunay tetrahedralization built incrementally "
                          "from a point set.")
@@ -56,4 +56,4 @@ void export_delaunay_module(nb::module_ &m) {
 } // namespace Delaunay
 } // namespace meshTools
 
-NB_MODULE(_delaunay, m) { meshTools::Delaunay::export_delaunay_module(m); }
+NB_MODULE(_delaunay, m) { meshTools::Delaunay::exportDelaunayModule(m); }

--- a/bindings/geometry_mesh/module_geometry.cpp
+++ b/bindings/geometry_mesh/module_geometry.cpp
@@ -22,11 +22,11 @@ template <class T, class B> static T getitem(const B &v, size_t index) {
 }
 
 // Expose Bbox::axis (Vector[3]) as a std::vector for Python indexing
-static std::vector<Vector> bbox_axis(const Bbox &b) {
+static std::vector<Vector> bboxAxis(const Bbox &b) {
     return {b.axis[0], b.axis[1], b.axis[2]};
 }
 
-void export_geometry_module(nb::module_ &m) {
+void exportGeometryModule(nb::module_ &m) {
     // Math functions
     m.def("epsilonTest", &math::epsilonTest, "value"_a, "test"_a = 0.0f,
           "eps"_a = 0.000001f, "Floating-point equality test");
@@ -105,7 +105,7 @@ void export_geometry_module(nb::module_ &m) {
         .def("obbFromPointSet", &Bbox::obbFromPointSet)
         .def("calcCenter", &Bbox::calcCenter)
         .def("__getitem__", &getitem<Vector, Bbox>)
-        .def_prop_ro("axis", &bbox_axis)
+        .def_prop_ro("axis", &bboxAxis)
         .def_prop_ro("min", [](const Bbox &b) { return b.min; })
         .def_prop_ro("max", [](const Bbox &b) { return b.max; })
         .def_prop_ro("center", [](const Bbox &b) { return b.center; });
@@ -157,4 +157,4 @@ void export_geometry_module(nb::module_ &m) {
 } // namespace Geometry
 } // namespace meshTools
 
-NB_MODULE(_geometry, m) { meshTools::Geometry::export_geometry_module(m); }
+NB_MODULE(_geometry, m) { meshTools::Geometry::exportGeometryModule(m); }

--- a/bindings/geometry_mesh/module_mesh.cpp
+++ b/bindings/geometry_mesh/module_mesh.cpp
@@ -10,7 +10,7 @@ namespace nb = nanobind;
 
 using namespace meshTools::Mesh;
 
-void export_mesh_module(nb::module_ &m) {
+void exportMeshModule(nb::module_ &m) {
     nb::class_<Vert>(m, "Vert")
         .def(nb::init<>())
         .def("computeNormal", &Vert::computeNormal);
@@ -20,4 +20,4 @@ void export_mesh_module(nb::module_ &m) {
         .def_prop_ro("verts", [](const Mesh &mesh) { return mesh.verts; });
 }
 
-NB_MODULE(_mesh, m) { export_mesh_module(m); }
+NB_MODULE(_mesh, m) { exportMeshModule(m); }

--- a/bindings/noise/module_noise.cpp
+++ b/bindings/noise/module_noise.cpp
@@ -7,7 +7,7 @@ using namespace nb::literals;
 namespace meshTools {
 namespace Noise {
 
-void export_noise_module(nb::module_ &m) {
+void exportNoiseModule(nb::module_ &m) {
     nb::class_<Noise>(m, "Noise",
                       "Procedural Simplex-style noise generator (2D, 3D, 4D).")
         .def(nb::init<>())
@@ -89,4 +89,4 @@ void export_noise_module(nb::module_ &m) {
 } // namespace Noise
 } // namespace meshTools
 
-NB_MODULE(_noise, m) { meshTools::Noise::export_noise_module(m); }
+NB_MODULE(_noise, m) { meshTools::Noise::exportNoiseModule(m); }

--- a/python/meshTools/maya/scatter.py
+++ b/python/meshTools/maya/scatter.py
@@ -21,7 +21,6 @@ def tileScatter(
     align_axis=1,
     srandom_rotate=Point(),
     srandom_translate=Point(),
-    srandom_scale=Point(),
     facing_sun=0.0,
 ):
     """copy_type = duplicate instance combine"""

--- a/src/bezier/curves.cpp
+++ b/src/bezier/curves.cpp
@@ -36,14 +36,14 @@ float b(float t)
         return 0.0f;
 }
 
-std::vector<float> Bezier::interpolate(const size_t &desired_num) {
+std::vector<float> Bezier::interpolate(const size_t &desiredNum) {
     std::vector<float> res;
     mNumPoints = mPoints.size();
     /* Make sure number of points is one more than a multiple of 3. */
     const size_t n = mNumPoints / 3 + (mNumPoints % 3) / 2;
 
-    const size_t num_segments = n / 3 + 1;
-    const float delta_t = float(num_segments) / float(desired_num - 1);
+    const size_t numSegments = n / 3 + 1;
+    const float deltaT = float(numSegments) / float(desiredNum - 1);
     /* Construct Bezier curves for each grouping of four points. */
     size_t count = 0;
     for (size_t i = 0; i < n + 1; i += 3) {
@@ -76,7 +76,7 @@ std::vector<float> Bezier::interpolate(const size_t &desired_num) {
         res.push_back(x);
         res.push_back(y);
         count++;
-        for (float t = delta_t; t < 1.0f - EPSILON; t += delta_t) {
+        for (float t = deltaT; t < 1.0f - EPSILON; t += deltaT) {
 
             x = ((ax * t + bx) * t + cx) * t + dx;
             y = ((ay * t + by) * t + cy) * t + dy;
@@ -90,12 +90,12 @@ std::vector<float> Bezier::interpolate(const size_t &desired_num) {
     return res;
 }
 
-std::vector<float> Lagrange::interpolate(const size_t &desired_num) {
+std::vector<float> Lagrange::interpolate(const size_t &desiredNum) {
     std::vector<float> res;
     mNumPoints = mPoints.size();
-    const float delta_t = 0.1f;
+    const float deltaT = 0.1f;
     /* Handle first set of 4 points between t=-1 and t=0 separately. */
-    for (float t = -1.0f; t < delta_t / 2.0f; t += delta_t) {
+    for (float t = -1.0f; t < deltaT / 2.0f; t += deltaT) {
         float x, y;
         const float b1 = B(1, t);
         const float b2 = B(2, t);
@@ -112,7 +112,7 @@ std::vector<float> Lagrange::interpolate(const size_t &desired_num) {
     /* Handle middle segments. */
 
     for (size_t i = 1; i <= mNumPoints / 3; i++) {
-        for (float t = delta_t; t < 1.0f + delta_t / 2.0f; t += delta_t) {
+        for (float t = deltaT; t < 1.0f + deltaT / 2.0f; t += deltaT) {
             float x, y;
             const float b1 = B(1, t);
             const float b2 = B(2, t);
@@ -130,7 +130,7 @@ std::vector<float> Lagrange::interpolate(const size_t &desired_num) {
 
     /* Handle the last set of 4 points between t=1.0 and t=2.0 separately. */
 
-    for (float t = 1.0f + delta_t; t < 2.0f + delta_t / 2.0f; t += delta_t) {
+    for (float t = 1.0f + deltaT; t < 2.0f + deltaT / 2.0f; t += deltaT) {
         float x, y;
         const float b1 = B(1, t);
         const float b2 = B(2, t);
@@ -147,15 +147,15 @@ std::vector<float> Lagrange::interpolate(const size_t &desired_num) {
 }
 
 std::vector<float> Spline1::interpolate(const std::vector<float> &mPoints,
-                                        const size_t &desired_num) {
+                                        const size_t &desiredNum) {
     std::vector<float> res;
 
-    if (desired_num == 0 || mPoints.empty()) {
+    if (desiredNum == 0 || mPoints.empty()) {
         return res;
     }
 
     const size_t mNumPoints = mPoints.size();
-    const float delta_t = 1.0f / float(desired_num);
+    const float deltaT = 1.0f / float(desiredNum);
 
     // Use std::vector for automatic memory management
     std::vector<float> points(mNumPoints + 8);
@@ -173,7 +173,7 @@ std::vector<float> Spline1::interpolate(const std::vector<float> &mPoints,
 
     /* Compute the values to plot. */
     for (size_t i = 0; i <= mNumPoints / 2; i++) {
-        for (float t = delta_t; t < 1.0f + delta_t / 2.0f; t += delta_t) {
+        for (float t = deltaT; t < 1.0f + deltaT / 2.0f; t += deltaT) {
             const float bt1 = b(t - 2.0f);
             const float bt2 = b(t - 1.0f);
             const float bt3 = b(t);
@@ -192,10 +192,10 @@ std::vector<float> Spline1::interpolate(const std::vector<float> &mPoints,
     return res;
 }
 
-std::vector<float> Spline::interpolate(const size_t &desired_num) {
+std::vector<float> Spline::interpolate(const size_t &desiredNum) {
     std::vector<float> res;
     mNumPoints = mPoints.size();
-    const float delta_t = 1 / float(desired_num);
+    const float deltaT = 1 / float(desiredNum);
     std::vector<float> points;
     points.resize(mNumPoints + 8);
 
@@ -216,7 +216,7 @@ std::vector<float> Spline::interpolate(const size_t &desired_num) {
 
     /* Compute the values to plot. */
     for (size_t i = 0; i <= mNumPoints / 2; i++) {
-        for (float t = delta_t; t < 1.0f + delta_t / 2.0f; t += delta_t) {
+        for (float t = deltaT; t < 1.0f + deltaT / 2.0f; t += deltaT) {
             const float bt1 = b(t - 2.0f);
             const float bt2 = b(t - 1.0f);
             const float bt3 = b(t);

--- a/src/bezier/curves.h
+++ b/src/bezier/curves.h
@@ -69,10 +69,10 @@ class Lagrange {
 
     /**
      * @brief Interpolate to generate a desired number of points
-     * @param desired_num Number of interpolated points to generate
+     * @param desiredNum Number of interpolated points to generate
      * @return Vector of interpolated values
      */
-    std::vector<float> interpolate(const size_t &desired_num);
+    std::vector<float> interpolate(const size_t &desiredNum);
 
   private:
     std::vector<float> mPoints; ///< Control points
@@ -102,10 +102,10 @@ class Bezier {
 
     /**
      * @brief Interpolate to generate a desired number of points
-     * @param desired_num Number of interpolated points to generate
+     * @param desiredNum Number of interpolated points to generate
      * @return Vector of interpolated values
      */
-    std::vector<float> interpolate(const size_t &desired_num);
+    std::vector<float> interpolate(const size_t &desiredNum);
 
   private:
     std::vector<float> mPoints; ///< Control points
@@ -134,10 +134,10 @@ class Spline {
 
     /**
      * @brief Interpolate to generate a desired number of points
-     * @param desired_num Number of interpolated points to generate
+     * @param desiredNum Number of interpolated points to generate
      * @return Vector of interpolated values
      */
-    std::vector<float> interpolate(const size_t &desired_num);
+    std::vector<float> interpolate(const size_t &desiredNum);
 
   private:
     std::vector<float> mPoints; ///< Control points
@@ -159,11 +159,11 @@ class Spline1 {
     /**
      * @brief Interpolate control points
      * @param mPoints Vector of control point values
-     * @param desired_num Desired number of samples per segment
+     * @param desiredNum Desired number of samples per segment
      * @return Vector of interpolated values (x,y pairs)
      */
     std::vector<float> interpolate(const std::vector<float> &mPoints,
-                                   const size_t &desired_num);
+                                   const size_t &desiredNum);
 };
 
 } // namespace curves

--- a/src/chull/chull.h
+++ b/src/chull/chull.h
@@ -21,14 +21,14 @@ struct ChullVertex {
     Geometry::Vector v;
     int vnum = 0;
     ChullEdge *duplicate = nullptr;
-    bool onhull = false;
+    bool onHull = false;
     bool mark = false;
 };
 
 struct ChullEdge {
-    ChullFace *adjface[2] = {nullptr, nullptr};
-    ChullVertex *endpts[2] = {nullptr, nullptr};
-    ChullFace *newface = nullptr;
+    ChullFace *adjFace[2] = {nullptr, nullptr};
+    ChullVertex *endPts[2] = {nullptr, nullptr};
+    ChullFace *newFace = nullptr;
     bool remove = false;
 };
 

--- a/src/delaunay/delaunay.cpp
+++ b/src/delaunay/delaunay.cpp
@@ -171,7 +171,7 @@ void Delaunay::pointInTetrahedra(size_t vIndex, size_t tetraIndex) {
 
 Delaunay::Delaunay(const std::vector<Geometry::Vector> &vertices,
                    float maxVal) {
-    orig_vertices_ = vertices;
+    origVertices_ = vertices;
     float k = 3.f * maxVal;
     vertices_.push_back(Geometry::Vector(k, 0.f, 0.f));
     vertices_.push_back(Geometry::Vector(-k, k, 0.f));
@@ -190,7 +190,7 @@ Delaunay::Delaunay(const std::vector<Geometry::Vector> &vertices,
     calculateCircumsphere(t0, vertices_);
     t0.parent = 0;
     tetras_.push_back(t0);
-    for (const auto &vert : orig_vertices_) {
+    for (const auto &vert : origVertices_) {
         vertices_.push_back(vert);
         size_t vi = vertices_.size() - 1;
         pointInTetrahedra(vi, 0);

--- a/src/delaunay/delaunay.h
+++ b/src/delaunay/delaunay.h
@@ -47,7 +47,7 @@ class Delaunay {
 
     /** Original input vertices (unchanged). */
     const std::vector<Geometry::Vector> &getOrigVertices() const {
-        return orig_vertices_;
+        return origVertices_;
     }
     /** All vertices (bounding + input). */
     const std::vector<Geometry::Vector> &getVertices() const {
@@ -57,7 +57,7 @@ class Delaunay {
     std::vector<std::vector<int>> getTetras() const;
 
   private:
-    std::vector<Geometry::Vector> orig_vertices_;
+    std::vector<Geometry::Vector> origVertices_;
     std::vector<Geometry::Vector> vertices_;
     std::vector<Tetra> tetras_;
 

--- a/src/geometry/bbox.cpp
+++ b/src/geometry/bbox.cpp
@@ -12,37 +12,37 @@ namespace meshTools {
 namespace Geometry {
 
 void Bbox::fromPointSet(const std::vector<Vector> &pointset) {
-    std::vector<Vector> sorted_pointset;
-    sorted_pointset = sortedVectorArray(pointset, 0);
-    min.x = sorted_pointset.front().x;
-    max.x = sorted_pointset.back().x;
-    sorted_pointset = sortedVectorArray(pointset, 1);
-    min.y = sorted_pointset.front().y;
-    max.y = sorted_pointset.back().y;
-    sorted_pointset = sortedVectorArray(pointset, 2);
-    min.z = sorted_pointset.front().z;
-    max.z = sorted_pointset.back().z;
+    std::vector<Vector> sortedPointset;
+    sortedPointset = sortedVectorArray(pointset, 0);
+    min.x = sortedPointset.front().x;
+    max.x = sortedPointset.back().x;
+    sortedPointset = sortedVectorArray(pointset, 1);
+    min.y = sortedPointset.front().y;
+    max.y = sortedPointset.back().y;
+    sortedPointset = sortedVectorArray(pointset, 2);
+    min.z = sortedPointset.front().z;
+    max.z = sortedPointset.back().z;
     calcCenter();
 }
-void swap(float first[3], float second[3]) { std::swap(first, second); }
+
 void Bbox::obbFromPointSet(const std::vector<Vector> &pointset) {
     Vector means;
-    const size_t pointset_size = pointset.size();
-    for (size_t i = 0; i < pointset_size; i++) {
+    const size_t pointsetSize = pointset.size();
+    for (size_t i = 0; i < pointsetSize; i++) {
         means += pointset[i];
     }
-    means /= static_cast<float>(pointset_size);
+    means /= static_cast<float>(pointsetSize);
     float m[3][3] = {{0, 0, 0}, {0, 0, 0}, {0, 0, 0}};
     float mc[3][3];
     float factor;
     m[2][2] = 1;
     for (int x = 0; x < 3; x++)
         for (int y = 0; y < 3; y++) {
-            for (int i = 0; i < pointset_size; i++) {
+            for (int i = 0; i < pointsetSize; i++) {
                 m[x][y] +=
                     (means[x] - pointset[i][x]) * (means[y] - pointset[i][y]);
             }
-            m[x][y] /= pointset_size;
+            m[x][y] /= pointsetSize;
         }
     float a, b, c, d;
     a = -1;
@@ -60,7 +60,7 @@ void Bbox::obbFromPointSet(const std::vector<Vector> &pointset) {
         mc[2][2] -= roots[i];
 
         if (mc[0][0] == 0) {
-            swap(mc[0], mc[2]);
+            std::swap(mc[0], mc[2]);
         } else {
             factor = mc[2][0] / mc[0][0];
             mc[2][0] += -mc[0][0] * factor;
@@ -69,7 +69,7 @@ void Bbox::obbFromPointSet(const std::vector<Vector> &pointset) {
         }
 
         if (mc[0][0] == 0) {
-            swap(mc[0], mc[1]);
+            std::swap(mc[0], mc[1]);
         } else {
             factor = mc[1][0] / mc[0][0];
             mc[1][0] += -mc[0][0] * factor;
@@ -78,7 +78,7 @@ void Bbox::obbFromPointSet(const std::vector<Vector> &pointset) {
         }
 
         if (mc[1][1] == 0) {
-            swap(mc[1], mc[2]);
+            std::swap(mc[1], mc[2]);
         } else {
             factor = mc[2][1] / mc[1][1];
             mc[2][0] += -mc[1][0] * factor;
@@ -92,7 +92,7 @@ void Bbox::obbFromPointSet(const std::vector<Vector> &pointset) {
 
     min = Vector(0, 0, 0);
     max = Vector(0, 0, 0);
-    for (size_t i = 0; i < pointset_size; i++) {
+    for (size_t i = 0; i < pointsetSize; i++) {
 
         const Vector &v =
             Vector(axis[0].dot(pointset[i]), axis[1].dot(pointset[i]),

--- a/src/geometry/lists.h
+++ b/src/geometry/lists.h
@@ -23,7 +23,7 @@ template <class T> class List : public std::vector<T> {
      * @param l The list to compare with
      * @return Grouped element
      */
-    T group_duplicates(const List<T> &l);
+    T groupDuplicates(const List<T> &l);
 
     /**
      * @brief Find the index of an item in the list
@@ -33,7 +33,7 @@ template <class T> class List : public std::vector<T> {
     unsigned int find(const T &item) const;
 };
 
-template <class T> T List<T>::group_duplicates(const List<T> &l) {}
+template <class T> T List<T>::groupDuplicates(const List<T> &l) {}
 
 template <class T> unsigned int List<T>::find(const T &item) const {
     typename List<T>::iterator h = std::find(this->begin(), this->end(), item);

--- a/src/geometry/polygon.cpp
+++ b/src/geometry/polygon.cpp
@@ -11,8 +11,8 @@ namespace Geometry {
 
 Polygon::Polygon(const std::vector<Vector> &points,
                  const std::vector<int> &indices, const Vector &normal)
-    : m_points(points), m_indices(indices), m_normal(normal) {
-    m_size = m_indices.size();
+    : mPoints(points), mIndices(indices), mNormal(normal) {
+    mSize = mIndices.size();
 }
 
 // Triangulate simple polygon using minimum angle ear clipping algorithm
@@ -20,28 +20,28 @@ std::vector<int> Polygon::triangulate() const {
     std::vector<int> resultIndices;
     float maxDot = 0.0f;
     size_t index = 0;
-    for (size_t i = 1; i < m_size; ++i) {
-        Vector edge0 = m_points[m_indices[i]] - m_points[m_indices[i - 1]];
+    for (size_t i = 1; i < mSize; ++i) {
+        Vector edge0 = mPoints[mIndices[i]] - mPoints[mIndices[i - 1]];
         Vector edge1 =
-            m_points[m_indices[i]] - m_points[m_indices[(i + 1) % m_size]];
+            mPoints[mIndices[i]] - mPoints[mIndices[(i + 1) % mSize]];
         edge0 = edge0.normalize();
         edge1 = edge1.normalize();
         float dot = edge0.dot(edge1);
         Vector normal = edge0.cross(edge1);
 
-        if (dot > maxDot && normal.dot(m_normal) < 0) {
+        if (dot > maxDot && normal.dot(mNormal) < 0) {
             index = i;
             maxDot = dot;
         }
     }
-    const size_t first = (int)index - 1 < 0 ? m_size - 1 : index - 1;
-    resultIndices.push_back(m_indices[first]);
-    resultIndices.push_back(m_indices[index]);
-    resultIndices.push_back(m_indices[(index + 1) % m_size]);
-    if (m_indices.size() > 3) {
-        std::vector<int> indices(m_indices);
+    const size_t first = (int)index - 1 < 0 ? mSize - 1 : index - 1;
+    resultIndices.push_back(mIndices[first]);
+    resultIndices.push_back(mIndices[index]);
+    resultIndices.push_back(mIndices[(index + 1) % mSize]);
+    if (mIndices.size() > 3) {
+        std::vector<int> indices(mIndices);
         indices.erase(indices.begin() + index);
-        const Polygon poly(m_points, indices, m_normal);
+        const Polygon poly(mPoints, indices, mNormal);
         const std::vector<int> triIndices = poly.triangulate();
         resultIndices.insert(resultIndices.end(), triIndices.begin(),
                              triIndices.end());

--- a/src/geometry/polygon.h
+++ b/src/geometry/polygon.h
@@ -36,10 +36,10 @@ class Polygon {
     std::vector<int> triangulate() const;
 
   private:
-    std::vector<Vector> m_points; ///< Vertex points of the polygon
-    std::vector<int> m_indices;   ///< Vertex indices
-    Vector m_normal;              ///< Normal vector of the polygon
-    size_t m_size;                ///< Number of vertices in the polygon
+    std::vector<Vector> mPoints; ///< Vertex points of the polygon
+    std::vector<int> mIndices;   ///< Vertex indices
+    Vector mNormal;              ///< Normal vector of the polygon
+    size_t mSize;                ///< Number of vertices in the polygon
 };
 
 } // namespace Geometry

--- a/src/geometry/ray.cpp
+++ b/src/geometry/ray.cpp
@@ -23,41 +23,41 @@ Vector Ray::pointProjection(const Vector &point) const {
 }
 
 Vector Ray::triangleRayHit(const Vector triangle[3]) const {
-    Vector ret, tvec, qvec;
+    Vector ret, tVec, qVec;
     const Vector edge1 = triangle[1] - triangle[0];
     const Vector edge2 = triangle[2] - triangle[0];
-    const Vector pvec = direction.cross(edge2);
+    const Vector pVec = direction.cross(edge2);
     float u, v, t;
-    const float det = edge1.dot(pvec);
+    const float det = edge1.dot(pVec);
     if (det > EPSILON) {
-        tvec = origin - triangle[0];
-        u = tvec.dot(pvec);
+        tVec = origin - triangle[0];
+        u = tVec.dot(pVec);
         if ((u < 0) || (u > det)) {
             return ret;
         }
-        qvec = tvec.cross(edge1);
-        v = direction.dot(qvec);
+        qVec = tVec.cross(edge1);
+        v = direction.dot(qVec);
         if ((v < 0) || (u + v > det)) {
             return ret;
         }
     } else if (det < -EPSILON) {
-        tvec = origin - triangle[0];
-        u = tvec.dot(pvec);
+        tVec = origin - triangle[0];
+        u = tVec.dot(pVec);
         if ((u > 0) || (u < det)) {
             return ret;
         }
-        qvec = tvec.cross(edge1);
-        v = direction.dot(qvec);
+        qVec = tVec.cross(edge1);
+        v = direction.dot(qVec);
         if ((v > 0) || (u + v < det)) {
             return ret;
         }
     } else {
         return ret;
     }
-    const float inv_det = 1 / det;
-    t = edge2.dot(qvec) * inv_det;
-    u = u * inv_det;
-    v = v * inv_det;
+    const float invDet = 1 / det;
+    t = edge2.dot(qVec) * invDet;
+    u = u * invDet;
+    v = v * invDet;
     return Vector(u, v, t);
 }
 

--- a/src/geometry/transform.cpp
+++ b/src/geometry/transform.cpp
@@ -73,17 +73,17 @@ Transform Transform::lookAt(const Vector &pos, const Vector &look,
     Transform t;
     const Vector dir = look - pos;
     const Vector left = dir.cross(up).normalize();
-    const Vector newup = dir.cross(left).normalize();
+    const Vector newUp = dir.cross(left).normalize();
     t.m[0][0] = left.x;
-    t.m[0][1] = newup.x;
+    t.m[0][1] = newUp.x;
     t.m[0][2] = dir.x;
     t.m[0][3] = pos.x;
     t.m[1][0] = left.y;
-    t.m[1][1] = newup.y;
+    t.m[1][1] = newUp.y;
     t.m[1][2] = dir.y;
     t.m[1][3] = pos.y;
     t.m[2][0] = left.z;
-    t.m[2][1] = newup.z;
+    t.m[2][1] = newUp.z;
     t.m[2][2] = dir.z;
     t.m[2][3] = pos.z;
     t.m[3][0] = 0;
@@ -211,19 +211,19 @@ Transform Transform::scaleLocal(float factor, const Vector &origin,
 
 Transform Transform::rotateX(float angle) const {
     Transform t;
-    const float sin_t = sin(angle);
-    const float cos_t = cos(angle);
+    const float sinT = sin(angle);
+    const float cosT = cos(angle);
     t.m[0][0] = 1;
     t.m[0][1] = 0;
     t.m[0][2] = 0;
     t.m[0][3] = 0;
     t.m[1][0] = 0;
-    t.m[1][1] = cos_t;
-    t.m[1][2] = -sin_t;
+    t.m[1][1] = cosT;
+    t.m[1][2] = -sinT;
     t.m[1][3] = 0;
     t.m[2][0] = 0;
-    t.m[2][1] = sin_t;
-    t.m[2][2] = cos_t;
+    t.m[2][1] = sinT;
+    t.m[2][2] = cosT;
     t.m[2][3] = 0;
     t.m[3][0] = 0;
     t.m[3][1] = 0;
@@ -234,19 +234,19 @@ Transform Transform::rotateX(float angle) const {
 
 Transform Transform::rotateY(float angle) const {
     Transform t;
-    const float sin_t = sin(angle);
-    const float cos_t = cos(angle);
-    t.m[0][0] = cos_t;
+    const float sinT = sin(angle);
+    const float cosT = cos(angle);
+    t.m[0][0] = cosT;
     t.m[0][1] = 0;
-    t.m[0][2] = sin_t;
+    t.m[0][2] = sinT;
     t.m[0][3] = 0;
     t.m[1][0] = 0;
     t.m[1][1] = 1;
     t.m[1][2] = 0;
     t.m[1][3] = 0;
-    t.m[2][0] = -sin_t;
+    t.m[2][0] = -sinT;
     t.m[2][1] = 0;
-    t.m[2][2] = cos_t;
+    t.m[2][2] = cosT;
     t.m[2][3] = 0;
     t.m[3][0] = 0;
     t.m[3][1] = 0;
@@ -257,14 +257,14 @@ Transform Transform::rotateY(float angle) const {
 
 Transform Transform::rotateZ(float angle) const {
     Transform t;
-    const float sin_t = sin(angle);
-    const float cos_t = cos(angle);
-    t.m[0][0] = cos_t;
-    t.m[0][1] = -sin_t;
+    const float sinT = sin(angle);
+    const float cosT = cos(angle);
+    t.m[0][0] = cosT;
+    t.m[0][1] = -sinT;
     t.m[0][2] = 0;
     t.m[0][3] = 0;
-    t.m[1][0] = sin_t;
-    t.m[1][1] = cos_t;
+    t.m[1][0] = sinT;
+    t.m[1][1] = cosT;
     t.m[1][2] = 0;
     t.m[1][3] = 0;
     t.m[2][0] = 0;


### PR DESCRIPTION
- Renamed export functions in bezier, chull, delaunay, geometry, mesh, and noise modules to follow a consistent camelCase naming convention.
- Updated variable names in the Bezier and Lagrange classes to use camelCase for parameters related to the desired number of interpolated points.
- Improved readability and maintainability of the codebase by standardizing naming conventions across multiple files.